### PR TITLE
Frame measurements to address hardware keyboard

### DIFF
--- a/Pod/Classes/HLMLayoutRootView.m
+++ b/Pod/Classes/HLMLayoutRootView.m
@@ -42,7 +42,7 @@
         BOOL const overridesKeyboardResizing = rootView.hlm_overridesKeyboardResizing;
         CGFloat const topGuideLength = self.topLayoutGuide.length;
         CGFloat const bottomGuideLength = self.bottomLayoutGuide.length;
-        CGFloat const keyboardFrameHeight = self.keyboardFrame.size.height;
+        CGFloat const keyboardFrameHeight = CGRectIsEmpty(self.keyboardFrame) ? : [UIScreen mainScreen].bounds.size.height - self.keyboardFrame.origin.y;
         CGFloat const previousPaddingTop = rootView.hlm_paddingTop;
         CGFloat const previousPaddingBottom = rootView.hlm_paddingBottom;
         if (!overridesLayoutGuides) {

--- a/Pod/Classes/HLMScrollView.m
+++ b/Pod/Classes/HLMScrollView.m
@@ -61,7 +61,7 @@
     if (view.hlm_orientation == HLMLayoutOrientationVertical) {
         uint32_t heightSize = [HLMLayout measureSpecSize:heightMeasureSpec];
         if (self.resizesForKeyboard) {
-            heightSize += self.keyboardFrame.size.height;
+            heightSize += CGRectIsEmpty(self.keyboardFrame) ? : [UIScreen mainScreen].bounds.size.height - self.keyboardFrame.origin.y;
         }
         HLMMeasureSpecMode heightMode = [HLMLayout measureSpecMode:heightMeasureSpec];
         [super measure:view
@@ -115,7 +115,7 @@
            bottom:bottom];
     CGSize contentSize = view.hlm_childView.bounds.size;
     if (self.resizesForKeyboard) {
-        contentSize.height += self.keyboardFrame.size.height;
+        contentSize.height += CGRectIsEmpty(self.keyboardFrame) ? : [UIScreen mainScreen].bounds.size.height - self.keyboardFrame.origin.y;
     }
     view.contentSize = contentSize;
 }

--- a/Pod/Classes/HLMViewController.h
+++ b/Pod/Classes/HLMViewController.h
@@ -11,5 +11,5 @@
 
 @interface HLMViewController : UIViewController
 @property (readonly) NSString* layoutResource;
-@property (readonly) BOOL shouldAnimateKeyboardHeight;
+@property (readonly) BOOL shouldAnimateKeyboardHeight; //Is this needed? Should it be readonly?
 @end

--- a/Pod/Classes/HLMViewController.m
+++ b/Pod/Classes/HLMViewController.m
@@ -98,7 +98,7 @@
     if (!self.isViewLoaded) {
         return;
     }
-    CGRect const frame = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    CGRect const frame = [self.view convertRect:[notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue] toView:nil];
     ((HLMLayoutRootView *) self.view).keyboardFrame = frame;
     if (self.shouldAnimateKeyboardHeight && !((HLMLayoutRootView *) self.view).rootView.hlm_overridesKeyboardResizing) {
         [UIView animateWithDuration:0.3f animations:^{


### PR DESCRIPTION
I believe there is a bit of silliness over the way iOS handles an `inputAccessoryView` and a hardware keyboard. I’ve had issues where if there is no `inputAccessoryView` on the first responder, `UIKeyboardWillShowNotification` is not triggered (and so Helium correctly measures assuming an empty keyboard frame). 

However, when there is an `inputAccessoryView` AND a hardware keyboard, the frame provided by `UIKeyboardWillShowNotification` is for the software keyboard (which is actually hidden) + the height of the `inputAccessoryView` (visible, but locked to the bottom of the window), and not the height of what is actually visible on the screen. This appears to cause Helium to incorrectly offset the height of views that are keyboard aware. 

Proposed changes are adapted from the discussion on H/W keyboards: http://stackoverflow.com/questions/2893267/how-can-i-detect-if-an-external-keyboard-is-present-on-an-ipad
